### PR TITLE
feat: use Members table as source of truth for club members

### DIFF
--- a/src/features/club-management/api/members.server.ts
+++ b/src/features/club-management/api/members.server.ts
@@ -1,0 +1,99 @@
+import { serverFetch } from "@/lib/server-fetch";
+import { REVALIDATE_SHORT } from "@/lib/cache-config";
+import { getCurrentClub } from "./club.server";
+import type { User } from "@/types";
+
+/**
+ * Server-side API for Club Members
+ *
+ * Functions to fetch club member data from Server Components
+ * Uses serverFetch with httpOnly cookies for auth
+ *
+ * SECURITY: Backend automatically filters by clubId
+ * Users can only see members from their own club
+ *
+ * Cache Strategy: REVALIDATE_SHORT (1 minute)
+ */
+
+interface MemberListReadModel {
+  id: string;
+  userId: string;
+  clubId: string;
+  role: string;
+  roleName: string;
+  joinedAt: Date;
+  isActive: boolean;
+  userFirstName?: string;
+  userLastName?: string;
+  userEmail?: string;
+  userAvatar?: string;
+  canManageClubSettings: boolean;
+  canManageTeams: boolean;
+  canInviteMembers: boolean;
+  canManageSubscription: boolean;
+  isCoach: boolean;
+  isAssistantCoach: boolean;
+  isPlayer: boolean;
+}
+
+interface MembersResponse {
+  success: boolean;
+  data: MemberListReadModel[];
+}
+
+/**
+ * Get all members from authenticated user's club
+ * Uses the Members table as source of truth
+ */
+export async function getClubMembers(): Promise<User[]> {
+  const club = await getCurrentClub();
+
+  if (!club) {
+    return [];
+  }
+
+  const response = await serverFetch<MembersResponse>(
+    `/clubs/${club.id}/members`,
+    {
+      next: { revalidate: REVALIDATE_SHORT },
+    },
+  );
+
+  if (!response?.data) {
+    return [];
+  }
+  //TODO: use a mapper to convert the response to the User type
+  return response.data.map((member) => ({
+    id: member.userId,
+    email: member.userEmail || "",
+    firstName: member.userFirstName || "",
+    lastName: member.userLastName || "",
+    avatar: member.userAvatar,
+    role: "USER" as const,
+    clubId: member.clubId,
+    clubRole: member.role as "COACH" | "ASSISTANT_COACH" | "PLAYER" | null,
+    isActive: member.isActive,
+    createdAt: member.joinedAt,
+    updatedAt: member.joinedAt,
+    lastLoginAt: undefined,
+  }));
+}
+
+/**
+ * Get members filtered by club role
+ */
+export async function getMembersByRole(
+  role: "COACH" | "ASSISTANT_COACH" | "PLAYER",
+): Promise<User[]> {
+  const members = await getClubMembers();
+  return members.filter((member) => member.clubRole === role);
+}
+
+/**
+ * Get count of members in the club
+ */
+export async function getClubMembersCount(): Promise<number> {
+  const members = await getClubMembers();
+  return members.length;
+}
+

--- a/src/features/dashboard/components/server/MembersWidgetServer.tsx
+++ b/src/features/dashboard/components/server/MembersWidgetServer.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { getClubUsers } from "@/features/users/api/users.server";
+import { getClubMembers } from "@/features/club-management/api/members.server";
 import { ROUTES } from "@/constants";
 import { DashboardCard } from "../DashboardCard";
 
@@ -12,7 +12,7 @@ import { DashboardCard } from "../DashboardCard";
  * Pattern: Server Component with async data fetching
  */
 export async function MembersWidgetServer() {
-  const members = await getClubUsers();
+  const members = await getClubMembers();
 
   return (
     <DashboardCard

--- a/src/features/players/PlayersListServer.tsx
+++ b/src/features/players/PlayersListServer.tsx
@@ -1,15 +1,16 @@
-import { getClubUsers } from "@/features/users/api/users.server";
+import { getClubMembers } from "@/features/club-management/api/members.server";
 import { PlayersSearch } from "./PlayersSearch";
 
 /**
  * PlayersListServer - Server Component
  *
- * Fetches club users server-side and passes to client search component
+ * Fetches club members server-side and passes to client search component
  * Separates data fetching (server) from interactivity (client)
+ * Uses Members table as source of truth (not User.clubRole)
  */
 
 export async function PlayersListServer() {
-  const players = await getClubUsers();
+  const players = await getClubMembers();
 
   return <PlayersSearch players={players} />;
 }

--- a/src/features/players/PlayersStatsGrid.tsx
+++ b/src/features/players/PlayersStatsGrid.tsx
@@ -1,21 +1,19 @@
-import {
-  getClubUsers,
-  getUsersByRole,
-} from "@/features/users/api/users.server";
+import { getClubMembers, getMembersByRole } from "@/features/club-management/api/members.server";
 
 /**
  * PlayersStatsGrid - Server Component
  *
  * Displays statistics cards for club members
- * Fetches user data server-side and calculates stats
+ * Fetches member data server-side and calculates stats
+ * Uses Members table as source of truth (not User.clubRole)
  */
 
 export async function PlayersStatsGrid() {
-  const clubPlayers = await getClubUsers();
-  const players = await getUsersByRole("PLAYER");
-  const coaches = clubPlayers.filter(
-    (player) =>
-      player.clubRole === "COACH" || player.clubRole === "ASSISTANT_COACH",
+  const clubMembers = await getClubMembers();
+  const players = await getMembersByRole("PLAYER");
+  const coaches = clubMembers.filter(
+    (member) =>
+      member.clubRole === "COACH" || member.clubRole === "ASSISTANT_COACH",
   );
 
   return (
@@ -37,7 +35,7 @@ export async function PlayersStatsGrid() {
               Total membres
             </p>
             <p className="text-2xl font-bold text-neutral-900">
-              {clubPlayers.length}
+              {clubMembers.length}
             </p>
           </div>
         </div>

--- a/src/features/users/api/users.server.ts
+++ b/src/features/users/api/users.server.ts
@@ -37,6 +37,8 @@ interface UserResponse {
 /**
  * Get all users from authenticated user's club
  * Backend automatically filters by user's clubId
+ * @deprecated Use getClubMembers() from @/features/club-management/api/members.server instead
+ * This function uses User.clubRole which may be out of sync with Member.role
  */
 export async function getClubUsers(): Promise<User[]> {
   const response = await serverFetch<UsersResponse>("/users", {
@@ -59,6 +61,7 @@ export async function getUser(userId: string): Promise<User | null> {
 
 /**
  * Get count of users in the club
+ * @deprecated Use getClubMembersCount() from @/features/club-management/api/members.server instead
  */
 export async function getClubUsersCount(): Promise<number> {
   const users = await getClubUsers();
@@ -67,6 +70,7 @@ export async function getClubUsersCount(): Promise<number> {
 
 /**
  * Get users filtered by club role
+ * @deprecated Use getMembersByRole() from @/features/club-management/api/members.server instead
  */
 export async function getUsersByRole(
   role: "COACH" | "ASSISTANT_COACH" | "PLAYER",


### PR DESCRIPTION
- Create getClubMembers() API function using /clubs/:clubId/members endpoint
- Replace getClubUsers() calls with getClubMembers() in PlayersListServer and PlayersStatsGrid
- Update MembersWidgetServer to use new members API
- Mark getClubUsers() as deprecated with migration note
- Members table is now the single source of truth for club member roles

# Pull Request Title

type(scope): short summary

## Summary
- Why
- What

## Changes
- Key changes
- ...

## Tests and Checks
- Frontend: `yarn lint`, `yarn build`

## Checklist
- [ ] Follows project Skills (`.claude/skills/`) and conventions
- [ ] No ESLint or TypeScript errors
- [ ] Tests added or updated
- [ ] Docs updated if needed
- [ ] No secrets committed

## Linked Issues
- Closes #
- Related to #

## Risk and Impact
- Breaking changes? If yes, describe impact and migration

## Deployment Notes
- Steps and rollback plan

## Reviewer Notes
- Areas to focus
