### PR TITLE
refactor: rename COACH to OWNER and ASSISTANT_COACH to COACH

### DIFF
--- a/src/app/(auth)/signup/assistant/page.tsx
+++ b/src/app/(auth)/signup/assistant/page.tsx
@@ -1,7 +1,7 @@
 /**
- * Page d'inscription Assistant Coach
+ * Page d'inscription Coach
  *
- * Formulaire d'inscription via invitation pour rejoindre un club en tant qu'assistant
+ * Formulaire d'inscription via invitation pour rejoindre un club en tant que coach
  */
 
 import Link from "next/link";
@@ -15,7 +15,7 @@ export default function SignupAssistantPage() {
       {/* Header */}
       <div className="text-center">
         <h1 className="text-3xl font-bold text-gray-900 font-heading">
-          Inscription Assistant Coach
+          Inscription Coach
         </h1>
         <p className="mt-2 text-sm text-gray-600">
           Rejoignez votre club via invitation

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -2,9 +2,9 @@
  * Page de sélection de rôle pour l'inscription
  *
  * Permet à l'utilisateur de choisir son rôle :
- * - Coach (créer un club)
+ * - Propriétaire (créer un club)
  * - Joueur (rejoindre via invitation)
- * - Assistant Coach (aider via invitation)
+ * - Coach (aider via invitation)
  */
 
 import Link from "next/link";

--- a/src/app/club/page.tsx
+++ b/src/app/club/page.tsx
@@ -6,7 +6,7 @@ import { ClubDetailsSkeleton } from "@/features/club-management/components/ClubD
  * Club Page - Server Component
  *
  * Detailed club page with all information
- * Accessible to all club members (COACH, ASSISTANT_COACH, PLAYER)
+ * Accessible to all club members (OWNER, COACH, PLAYER)
  *
  * Pattern: Server Component + Suspense
  */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,9 +21,9 @@ export default function HomePage() {
       return;
     }
 
-    if (clubRole === "COACH") {
+    if (clubRole === "OWNER") {
       router.push(ROUTES.DASHBOARD.COACH);
-    } else if (clubRole === "ASSISTANT_COACH") {
+    } else if (clubRole === "COACH") {
       router.push(ROUTES.DASHBOARD.ASSISTANT);
     } else if (clubRole === "PLAYER") {
       router.push(ROUTES.DASHBOARD.PLAYER);

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -40,8 +40,8 @@ export function AppHeader() {
     return null;
   }
 
+  const isOwner = clubRole === "OWNER";
   const isCoach = clubRole === "COACH";
-  const isAssistant = clubRole === "ASSISTANT_COACH";
 
   // Get navigation links based on role
   const navLinks = getNavLinks(clubRole);
@@ -72,9 +72,9 @@ export function AppHeader() {
       <header className="md:hidden fixed top-0 left-0 right-0 h-16 bg-surface border-b-[12px] border-border-emphasis shadow-sm flex items-center justify-between px-4 z-50">
         <Link
           href={
-            isCoach
+            isOwner
               ? ROUTES.DASHBOARD.COACH
-              : isAssistant
+              : isCoach
                 ? ROUTES.DASHBOARD.ASSISTANT
                 : ROUTES.DASHBOARD.PLAYER
           }
@@ -157,14 +157,14 @@ export function AppHeader() {
                   </p>
                   <p
                     className={`text-xs truncate ${
-                      isCoach
+                      isOwner
                         ? "text-orange-600"
-                        : isAssistant
+                        : isCoach
                           ? "text-blue-600"
                           : "text-green-600"
                     }`}
                   >
-                    {isCoach ? "Coach" : isAssistant ? "Assistant" : "Joueur"}
+                    {isOwner ? "Propriétaire" : isCoach ? "Coach" : "Joueur"}
                   </p>
                 </div>
               </Link>
@@ -190,9 +190,9 @@ export function AppHeader() {
         <div className="p-6 border-b-6 border-white">
           <Link
             href={
-              isCoach
+              isOwner
                 ? ROUTES.DASHBOARD.COACH
-                : isAssistant
+                : isCoach
                   ? ROUTES.DASHBOARD.ASSISTANT
                   : ROUTES.DASHBOARD.PLAYER
             }
@@ -250,15 +250,15 @@ export function AppHeader() {
                 {user?.firstName} {user?.lastName}
               </p>
               <p
-                className={`text-xs truncate ${
-                  isCoach
-                    ? "text-orange-600"
-                    : isAssistant
-                      ? "text-blue-600"
-                      : "text-green-600"
-                }`}
-              >
-                {isCoach ? "Coach" : isAssistant ? "Assistant" : "Joueur"}
+                  className={`text-xs truncate ${
+                    isOwner
+                      ? "text-orange-600"
+                      : isCoach
+                        ? "text-blue-600"
+                        : "text-green-600"
+                  }`}
+                >
+                  {isOwner ? "Propriétaire" : isCoach ? "Coach" : "Joueur"}
               </p>
             </div>
           </Link>

--- a/src/config/navigation.config.ts
+++ b/src/config/navigation.config.ts
@@ -8,7 +8,7 @@ import {
 } from "@tabler/icons-react";
 import { ROUTES } from "../constants";
 
-export type ClubRole = "COACH" | "ASSISTANT_COACH" | "PLAYER";
+export type ClubRole = "OWNER" | "COACH" | "PLAYER";
 
 export interface NavLink {
   href: string;
@@ -24,43 +24,43 @@ export interface NavLink {
  * @returns Liste des liens de navigation
  */
 export function getNavLinks(clubRole: ClubRole | null): NavLink[] {
+  const isOwner = clubRole === "OWNER";
   const isCoach = clubRole === "COACH";
-  const isAssistant = clubRole === "ASSISTANT_COACH";
 
   return [
     {
-      href: isCoach
+      href: isOwner
         ? ROUTES.DASHBOARD.COACH
-        : isAssistant
+        : isCoach
           ? ROUTES.DASHBOARD.ASSISTANT
           : ROUTES.DASHBOARD.PLAYER,
       label: "Dashboard",
       icon: IconLayoutDashboard,
-      roles: ["COACH", "ASSISTANT_COACH", "PLAYER"],
+      roles: ["OWNER", "COACH", "PLAYER"],
     },
     {
       href: ROUTES.CLUB,
       label: "Mon club",
       icon: IconBallVolleyball,
-      roles: ["COACH", "ASSISTANT_COACH", "PLAYER"],
+      roles: ["OWNER", "COACH", "PLAYER"],
     },
     {
       href: ROUTES.TEAMS,
       label: "Mes équipes",
       icon: IconUsers,
-      roles: ["COACH", "ASSISTANT_COACH", "PLAYER"],
+      roles: ["OWNER", "COACH", "PLAYER"],
     },
     {
       href: ROUTES.PLAYERS,
       label: "Mes joueurs",
       icon: IconPlayVolleyball,
-      roles: ["COACH"],
+      roles: ["OWNER"],
     },
     {
       href: ROUTES.MATCHES,
       label: "Matchs",
       icon: IconCalendar,
-      roles: ["COACH", "ASSISTANT_COACH", "PLAYER"],
+      roles: ["OWNER", "COACH", "PLAYER"],
     },
   ];
 }

--- a/src/features/auth/api/signup.api.ts
+++ b/src/features/auth/api/signup.api.ts
@@ -146,7 +146,7 @@ export async function validateInvitationToken(
   const data = extractData<{
     clubName: string;
     clubId: string;
-    type: "PLAYER" | "ASSISTANT_COACH";
+    type: "PLAYER" | "COACH";
     expiresAt?: string;
   }>(responseData);
 

--- a/src/features/auth/components/signup/AssistantSignupForm.tsx
+++ b/src/features/auth/components/signup/AssistantSignupForm.tsx
@@ -1,7 +1,7 @@
 /**
- * AssistantSignupForm Component (Smart)
+ * CoachSignupForm Component (Smart)
  *
- * Formulaire d'inscription pour un coach assistant via invitation
+ * Formulaire d'inscription pour un coach via invitation
  * - Validation du token d'invitation
  * - Affichage du nom du club
  * - Warning si changement de club

--- a/src/features/auth/components/signup/RoleSelector.tsx
+++ b/src/features/auth/components/signup/RoleSelector.tsx
@@ -23,7 +23,7 @@ interface RoleOption {
 
 const roleOptions: RoleOption[] = [
   {
-    title: "Coach",
+    title: "Propriétaire",
     description: "Créez votre club et gérez vos équipes",
     icon: "👨‍🏫",
     href: ROUTES.SIGNUP.COACH,
@@ -36,7 +36,7 @@ const roleOptions: RoleOption[] = [
     href: ROUTES.SIGNUP.PLAYER,
   },
   {
-    title: "Assistant Coach",
+    title: "Coach",
     description: "Aidez à gérer un club via une invitation",
     icon: "🤝",
     href: ROUTES.SIGNUP.ASSISTANT,

--- a/src/features/auth/types/signup.types.ts
+++ b/src/features/auth/types/signup.types.ts
@@ -73,7 +73,7 @@ export interface SignupResponse {
     lastName: string;
     role: "USER" | "ADMIN";
     clubId: string | null;
-    clubRole: "COACH" | "ASSISTANT_COACH" | "PLAYER" | null;
+    clubRole: "OWNER" | "COACH" | "PLAYER" | null;
   };
 
   // Informations supplémentaires pour le coach
@@ -94,7 +94,7 @@ export interface InvitationValidation {
   isValid: boolean;
   clubName?: string;
   clubId?: string;
-  invitationType?: "PLAYER" | "ASSISTANT_COACH";
+  invitationType?: "PLAYER" | "COACH";
   expiresAt?: Date;
   error?: string;
 }

--- a/src/features/club-management/api/members.server.ts
+++ b/src/features/club-management/api/members.server.ts
@@ -31,8 +31,8 @@ interface MemberListReadModel {
   canManageTeams: boolean;
   canInviteMembers: boolean;
   canManageSubscription: boolean;
+  isOwner: boolean;
   isCoach: boolean;
-  isAssistantCoach: boolean;
   isPlayer: boolean;
 }
 
@@ -71,7 +71,7 @@ export async function getClubMembers(): Promise<User[]> {
     avatar: member.userAvatar,
     role: "USER" as const,
     clubId: member.clubId,
-    clubRole: member.role as "COACH" | "ASSISTANT_COACH" | "PLAYER" | null,
+    clubRole: member.role as "OWNER" | "COACH" | "PLAYER" | null,
     isActive: member.isActive,
     createdAt: member.joinedAt,
     updatedAt: member.joinedAt,
@@ -83,7 +83,7 @@ export async function getClubMembers(): Promise<User[]> {
  * Get members filtered by club role
  */
 export async function getMembersByRole(
-  role: "COACH" | "ASSISTANT_COACH" | "PLAYER",
+  role: "OWNER" | "COACH" | "PLAYER",
 ): Promise<User[]> {
   const members = await getClubMembers();
   return members.filter((member) => member.clubRole === role);

--- a/src/features/club-management/components/invitations/InvitationLinkGenerator.tsx
+++ b/src/features/club-management/components/invitations/InvitationLinkGenerator.tsx
@@ -81,8 +81,8 @@ export function InvitationLinkGenerator({
                 label: "Joueur",
               },
               {
-                value: "ASSISTANT_COACH",
-                label: "Assistant Coach",
+                value: "COACH",
+                label: "Coach",
               },
             ]}
             disabled={isLoading}
@@ -90,7 +90,7 @@ export function InvitationLinkGenerator({
           <p className="mt-2 text-sm text-gray-500">
             {invitationType === "PLAYER"
               ? "Les joueurs pourront rejoindre vos équipes"
-              : "Les assistants pourront gérer les équipes avec vous"}
+              : "Les coaches pourront gérer les équipes avec vous"}
           </p>
         </div>
 

--- a/src/features/club-management/components/members/MemberCard.tsx
+++ b/src/features/club-management/components/members/MemberCard.tsx
@@ -23,14 +23,14 @@ export function MemberCard({
 }: MemberCardProps) {
   const getRoleBadge = () => {
     const roleColors = {
-      COACH: "bg-purple-100 text-purple-800",
-      ASSISTANT_COACH: "bg-blue-100 text-blue-800",
+      OWNER: "bg-purple-100 text-purple-800",
+      COACH: "bg-blue-100 text-blue-800",
       PLAYER: "bg-green-100 text-green-800",
     };
 
     const roleLabels = {
-      COACH: "Entraîneur",
-      ASSISTANT_COACH: "Assistant",
+      OWNER: "Propriétaire",
+      COACH: "Coach",
       PLAYER: "Joueur",
     };
 

--- a/src/features/club-management/hooks/useInvitation.ts
+++ b/src/features/club-management/hooks/useInvitation.ts
@@ -102,10 +102,10 @@ export function useInvitation() {
    * Build full invitation URL
    */
   const buildInvitationUrl = useCallback(
-    (token: string, type: "ASSISTANT_COACH" | "PLAYER") => {
+    (token: string, type: "COACH" | "PLAYER") => {
       const baseUrl = window.location.origin;
       const path =
-        type === "ASSISTANT_COACH" ? "/signup/assistant" : "/signup/player";
+        type === "COACH" ? "/signup/coach" : "/signup/player";
       return `${baseUrl}${path}?invitation=${token}`;
     },
     [],

--- a/src/features/club-management/types/invitation.types.ts
+++ b/src/features/club-management/types/invitation.types.ts
@@ -7,7 +7,7 @@
 /**
  * Invitation type
  */
-export type InvitationType = "ASSISTANT_COACH" | "PLAYER";
+export type InvitationType = "COACH" | "PLAYER";
 
 /**
  * Invitation detail - Matches InvitationDetailReadModel from backend

--- a/src/features/club-management/types/member.types.ts
+++ b/src/features/club-management/types/member.types.ts
@@ -7,7 +7,7 @@
 /**
  * Club role for members
  */
-export type ClubRole = "COACH" | "ASSISTANT_COACH" | "PLAYER";
+export type ClubRole = "OWNER" | "COACH" | "PLAYER";
 
 /**
  * Member detail - Matches MemberListReadModel from backend

--- a/src/features/players/PlayerCard.tsx
+++ b/src/features/players/PlayerCard.tsx
@@ -52,9 +52,9 @@ export function PlayerCard({ player }: PlayerCardProps) {
 function getRoleBadge(role?: string | null): string {
   const baseClasses = "px-2 py-1 text-xs font-medium rounded-full";
   switch (role) {
-    case "COACH":
+    case "OWNER":
       return `${baseClasses} bg-orange-100 text-orange-800`;
-    case "ASSISTANT_COACH":
+    case "COACH":
       return `${baseClasses} bg-blue-100 text-blue-800`;
     case "PLAYER":
       return `${baseClasses} bg-green-100 text-green-800`;
@@ -68,10 +68,10 @@ function getRoleBadge(role?: string | null): string {
  */
 function getRoleLabel(role?: string | null): string {
   switch (role) {
+    case "OWNER":
+      return "Propriétaire";
     case "COACH":
       return "Coach";
-    case "ASSISTANT_COACH":
-      return "Assistant";
     case "PLAYER":
       return "Joueur";
     default:

--- a/src/features/players/PlayerProfileCard.tsx
+++ b/src/features/players/PlayerProfileCard.tsx
@@ -57,10 +57,10 @@ export function PlayerProfileCard({ user, level }: PlayerProfileCardProps) {
 
 function getRoleLabel(role?: string | null): string {
   switch (role) {
+    case "OWNER":
+      return "Propriétaire";
     case "COACH":
       return "Coach";
-    case "ASSISTANT_COACH":
-      return "Assistant";
     case "PLAYER":
       return "Joueur";
     default:

--- a/src/features/players/PlayersStatsGrid.tsx
+++ b/src/features/players/PlayersStatsGrid.tsx
@@ -13,7 +13,7 @@ export async function PlayersStatsGrid() {
   const players = await getMembersByRole("PLAYER");
   const coaches = clubMembers.filter(
     (member) =>
-      member.clubRole === "COACH" || member.clubRole === "ASSISTANT_COACH",
+      member.clubRole === "OWNER" || member.clubRole === "COACH",
   );
 
   return (

--- a/src/features/users/api/users.server.ts
+++ b/src/features/users/api/users.server.ts
@@ -73,7 +73,7 @@ export async function getClubUsersCount(): Promise<number> {
  * @deprecated Use getMembersByRole() from @/features/club-management/api/members.server instead
  */
 export async function getUsersByRole(
-  role: "COACH" | "ASSISTANT_COACH" | "PLAYER",
+  role: "OWNER" | "COACH" | "PLAYER",
 ): Promise<User[]> {
   const users = await getClubUsers();
   return users.filter((user) => user.clubRole === role);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,7 +14,7 @@ export interface User {
 }
 
 export type UserRole = "USER" | "ADMIN";
-export type ClubRole = "COACH" | "ASSISTANT_COACH" | "PLAYER" | null;
+export type ClubRole = "OWNER" | "COACH" | "PLAYER" | null;
 
 export interface UserCreateData {
   readonly email: string;


### PR DESCRIPTION
## Description

This PR implements the frontend changes for the role refactoring:
- `COACH` → `OWNER`
- `ASSISTANT_COACH` → `COACH`

## Changes

### Types
- Updated `ClubRole` type definitions
- Updated `InvitationType` type definitions
- Updated member and user types

### Components
- Updated `AppHeader` - role display and navigation
- Updated `MemberCard` - role badges and labels
- Updated `PlayerCard` - role badges and labels
- Updated `PlayerProfileCard` - role labels
- Updated `PlayersStatsGrid` - coach filtering logic
- Updated `InvitationLinkGenerator` - invitation type options
- Updated `RoleSelector` - signup role options
- Updated `AssistantSignupForm` - coach signup form

### Configuration
- Updated `navigation.config.ts` - role-based navigation links
- Updated route redirections based on roles

### API Routes
- Updated `members.server.ts` - member filtering and types
- Updated `signup.api.ts` - invitation validation and signup
- Updated `users.server.ts` - role filtering

### Pages
- Updated signup pages (`/signup`, `/signup/assistant`)
- Updated home page (`/`) - role-based redirection
- Updated club page (`/club`)

## Testing

- ✅ All TypeScript types updated
- ✅ All components updated with new role structure
- ✅ Navigation and routing updated